### PR TITLE
Add wiki handling

### DIFF
--- a/R/borrow_chapter.R
+++ b/R/borrow_chapter.R
@@ -40,8 +40,8 @@
 #' borrow_chapter(doc_path = "02-chapter_of_course.Rmd")
 #' # ```
 #' }
-borrow_chapter <- function(doc_path,
-                           repo_name = NULL,
+borrow_chapter <- function(doc_path = "Set-up-feedback-method.md",
+                           repo_name = "wiki/jhudsl/OTTR_Template",
                            branch = "main",
                            git_pat = NULL,
                            base_url = "https://raw.githubusercontent.com",
@@ -52,13 +52,28 @@ borrow_chapter <- function(doc_path,
   doc_path <- file.path(doc_path)
   doc_name <- basename(doc_path)
   
+  # Is this a wiki page? 
+  is_wiki <- grepl("^wiki\\/", repo_name)
+  
+  # There's not remote branches for wiki
+  if (is_wiki) {
+    branch = ""
+  }
+  
   if (!is.null(repo_name)) {
-    exists <- check_git_repo(
-      repo_name = repo_name,
-      git_pat = git_pat,
-      verbose = FALSE,
-      silent = TRUE
-    )
+    
+    # check_git_repo() does not work for wiki pages
+    if (!is_wiki) {
+      exists <- cow::check_git_repo(
+        repo_name = repo_name,
+        git_pat = git_pat,
+        verbose = FALSE,
+        silent = TRUE
+      )
+      if (!exists) {
+        warning(paste(repo_name, "was not found in GitHub. If it is a private repository, make sure your credentials have been provided"))
+      }
+    }
     
     # Create folder if it doesn't exist
     if (!dir.exists(dest_dir)) {
@@ -67,13 +82,16 @@ borrow_chapter <- function(doc_path,
     
     dest_file <- file.path(dest_dir, doc_name)
     
+    # Piece together URL
     full_url <- file.path(base_url, repo_name, branch, doc_path)
     
-    # Progress message
-    message(full_url)
-    
     # Download it
-    download.file(full_url, destfile = dest_file, quiet = TRUE)
+    response <- try(download.file(full_url, destfile = dest_file, quiet = TRUE))
+    
+    # Let us know if the url didn't work
+    if (grepl("Error", response)) {
+      stop("URL failed: ", full_url, "\n Double check doc_path and repo_name (and branch if set)")
+    }
   } else {
     # If the file is local we don't need to download anything
     dest_file <- doc_path

--- a/R/borrow_chapter.R
+++ b/R/borrow_chapter.R
@@ -40,8 +40,8 @@
 #' borrow_chapter(doc_path = "02-chapter_of_course.Rmd")
 #' # ```
 #' }
-borrow_chapter <- function(doc_path = "Set-up-feedback-method.md",
-                           repo_name = "wiki/jhudsl/OTTR_Template",
+borrow_chapter <- function(doc_path,
+                           repo_name = NULL,
                            branch = "main",
                            git_pat = NULL,
                            base_url = "https://raw.githubusercontent.com",


### PR DESCRIPTION
There were some quirks about wiki pages that make them not act like repositories that I didn't previously understand. These quirks meant I had to add som extra handling for borrow_chapters to work with GitHub wiki pages (which is what I need it for on https://github.com/jhudsl/Intro_to_OTTR/pull/14) 